### PR TITLE
Add ROM gem dependencies and relation class

### DIFF
--- a/hanami-db.gemspec
+++ b/hanami-db.gemspec
@@ -21,6 +21,8 @@ Gem::Specification.new do |spec|
   }
 
   spec.required_ruby_version = ">= 3.0.0"
+  spec.add_dependency "rom", "~> 5.3"
+  spec.add_dependency "rom-sql", "~> 3.6"
   spec.add_dependency "zeitwerk", "~> 2.6"
 
   spec.extra_rdoc_files = Dir["README*", "LICENSE*"]

--- a/lib/hanami/db.rb
+++ b/lib/hanami/db.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "rom"
+require "rom-sql"
 require "zeitwerk"
 
 module Hanami

--- a/lib/hanami/db/relation.rb
+++ b/lib/hanami/db/relation.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module Hanami
+  module DB
+    # @api public
+    # @since 2.2.0
+    class Relation < ROM::Relation[:sql]
+    end
+  end
+end

--- a/spec/unit/relation_spec.rb
+++ b/spec/unit/relation_spec.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+RSpec.describe Hanami::DB::Relation do
+  subject(:relation) { Class.new(described_class) }
+
+  it "defaults to the :sql adapter" do
+    expect(relation.adapter).to eq :sql
+  end
+end


### PR DESCRIPTION
Bring in rom and rom-sql gem dependencies, and create a Hanami::DB::Relation class, which defaults to using the :sql adapter.