### PR TITLE
Add private interface for transforming a database url

### DIFF
--- a/lib/hanami/db/testing.rb
+++ b/lib/hanami/db/testing.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require "uri"
+
+module Hanami
+  module DB
+    module Testing
+      # Replaces development suffix in test mode
+      #
+      # @api private
+      # @since 2.2.0
+      DATABASE_NAME_SUFFIX = "_test"
+
+      # @api private
+      # @since 2.2.0
+      DATABASE_NAME_MATCHER = /_dev(elopment)?$/
+      private_constant :DATABASE_NAME_MATCHER
+
+      # @api private
+      # @since 2.2.0
+      def self.database_url(url)
+        url = URI(url.to_s)
+
+        if url.path =~ DATABASE_NAME_MATCHER
+          url.path = url.path.sub(DATABASE_NAME_MATCHER, DATABASE_NAME_SUFFIX)
+        elsif !url.path.end_with?(DATABASE_NAME_SUFFIX)
+          url.path << DATABASE_NAME_SUFFIX
+        end
+
+        url.to_s
+      end
+    end
+  end
+end

--- a/spec/unit/testing/database_url_spec.rb
+++ b/spec/unit/testing/database_url_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+RSpec.describe Hanami::DB::Testing do
+  subject { described_class.method(:database_url) }
+
+  it "transforms _dev to _test" do
+    expect(subject.call("/bookshelf_dev")).to eq "/bookshelf_test"
+  end
+
+  it "transforms _development to _test" do
+    expect(subject.call("/bookshelf_development")).to eq "/bookshelf_test"
+  end
+
+  it "does not transform _test" do
+    expect(subject.call("/bookshelf_test")).to eq "/bookshelf_test"
+  end
+
+  it "appends to non-conforming paths" do
+    expect(subject.call("/bookshelf_database")).to eq "/bookshelf_database_test"
+  end
+
+  it "accepts any #to_s object such as URI" do
+    url = URI("postgres://localhost:5432/bookshelf_development")
+    expect(subject.call(url)).to eq "postgres://localhost:5432/bookshelf_test"
+  end
+end


### PR DESCRIPTION
This provides a single interface for transforming database urls to be used in hanami/hanami#1395

Since we agree that there is no need to support customization of this logic presently, I believe it would be best to provide a single interface that could be overloaded if someone really needed to change this.

It also makes unit-testing the behavior simpler.