### PR TITLE
Introduce Repo class

### DIFF
--- a/lib/hanami/db/repo.rb
+++ b/lib/hanami/db/repo.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module Hanami
+  module DB
+    # @api public
+    # @since 2.2.0
+    class Repo < ROM::Repository
+      # @api public
+      # @since 2.2.0
+      defines :root
+
+      # @api public
+      # @since 2.2.0
+      attr_reader :root
+
+      # @api private
+      def self.inherited(klass)
+        super
+        klass.root(root)
+      end
+
+      # @api public
+      # @since 2.2.0
+      def initialize(*, **)
+        super
+
+        @root = set_relation(self.class.root) if self.class.root
+      end
+    end
+  end
+end


### PR DESCRIPTION
The bulk of the integration code will be in hanami/hanami, so we’re keeping that alongside the app integration code for actions and views.

This leaves just a simple skeleton class to reside in hanami-db for now.