### PR TITLE
Alternate relation adapter testcase

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,8 @@ group :development do
   gem "rubocop"
 end
 
+gem "sqlite3"
+
 group :docs do
   gem "redcarpet", platforms: :mri
   gem "yard"

--- a/spec/unit/relation_spec.rb
+++ b/spec/unit/relation_spec.rb
@@ -1,9 +1,45 @@
 # frozen_string_literal: true
 
 RSpec.describe Hanami::DB::Relation do
-  subject(:relation) { Class.new(described_class) }
+  let :adapters do
+    {
+      default: [:sql, "sqlite::memory"],
+      alternate: [:memory, "memory://test"]
+    }
+  end
 
-  it "defaults to the :sql adapter" do
-    expect(relation.adapter).to eq :sql
+  let!(:config) { ROM::Configuration.new(adapters) }
+
+  before do
+    module Test
+      class User < Hanami::DB::Relation
+        schema(:users) {} # rubocop:disable Lint/EmptyBlock
+      end
+
+      class APITokens < Hanami::DB::Relation[:memory]
+        schema(:api_tokens) {} # rubocop:disable Lint/EmptyBlock
+      end
+    end
+
+    config.register_relation Test::User
+    config.register_relation Test::APITokens
+  end
+
+  subject(:rom) { ROM.container(config) }
+
+  context "no adapter specified" do
+    subject(:relation) { rom.relations[:users] }
+
+    it "chooses the default" do
+      expect(relation.adapter).to eq :sql
+    end
+  end
+
+  context "adapter is specified" do
+    subject(:relation) { rom.relations[:api_tokens] }
+
+    it "chooses the given adapter" do
+      expect(relation.adapter).to eq :memory
+    end
   end
 end


### PR DESCRIPTION
`Hanami::DB::Relation` will retain the ROM behavior of selecting an
alternate adapter with Relation[adapter_name] syntax, so this needs to
have test coverage.

Closes #3