### PR TITLE
Require rom-sql 3.6.4 or newer

### DIFF
--- a/hanami-db.gemspec
+++ b/hanami-db.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = ">= 3.0.0"
   spec.add_dependency "rom", "~> 5.3"
-  spec.add_dependency "rom-sql", "~> 3.6"
+  spec.add_dependency "rom-sql", "~> 3.6", ">= 3.6.4"
   spec.add_dependency "zeitwerk", "~> 2.6"
 
   spec.extra_rdoc_files = Dir["README*", "LICENSE*"]


### PR DESCRIPTION
3.6.4 includes a fix for instrumentation, which we need for Hanami's integration.

See https://github.com/rom-rb/rom-sql/pull/428 for details.