### PR TITLE
Struct serialize to json

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,6 @@ group :development do
 end
 
 gem "sqlite3"
-gem 'byebug'
 
 group :docs do
   gem "redcarpet", platforms: :mri

--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,7 @@ group :development do
 end
 
 gem "sqlite3"
+gem 'byebug'
 
 group :docs do
   gem "redcarpet", platforms: :mri

--- a/lib/hanami/db/struct.rb
+++ b/lib/hanami/db/struct.rb
@@ -8,8 +8,9 @@ module Hanami
       # @api public
       # @since 2.2.0
       #
-      # Simple conversion of attributes to JSON format, without this method, the instance of the struct gets converted to a string
-      def to_json
+      # Simple conversion of attributes to JSON format, without this method, the instance of the struct gets converted
+      # to a string
+      def to_json(*_args)
         to_h.to_json
       end
     end

--- a/lib/hanami/db/struct.rb
+++ b/lib/hanami/db/struct.rb
@@ -5,7 +5,10 @@ module Hanami
     # @api public
     # @since 2.2.0
     class Struct < ROM::Struct
-
+      # @api public
+      # @since 2.2.0
+      #
+      # Simple conversion of attributes to JSON format, without this method, the instance of the struct gets converted to a string
       def to_json
         to_h.to_json
       end

--- a/lib/hanami/db/struct.rb
+++ b/lib/hanami/db/struct.rb
@@ -5,6 +5,10 @@ module Hanami
     # @api public
     # @since 2.2.0
     class Struct < ROM::Struct
+
+      def to_json
+        to_h.to_json
+      end
     end
   end
 end

--- a/lib/hanami/db/struct.rb
+++ b/lib/hanami/db/struct.rb
@@ -10,8 +10,8 @@ module Hanami
       #
       # Simple conversion of attributes to JSON format, without this method, the instance of the struct gets converted
       # to a string
-      def to_json(*_args)
-        to_h.to_json
+      def to_json(*args)
+        to_h.to_json(*args)
       end
     end
   end

--- a/spec/unit/struct_spec.rb
+++ b/spec/unit/struct_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'byebug'
-
 RSpec.describe Hanami::DB::Struct do
   let!(:config) do
     ROM::Configuration.new(:sql, 'sqlite::memory') do |conf|
@@ -44,8 +42,7 @@ RSpec.describe Hanami::DB::Struct do
       repo = Test::UserRepo.new(rom)
       struct = repo.users.by_pk(1).one!
       expect(struct.full_name).to eq "L L"
-      byebug
-      expect(struct.to_json).to eq "{\"first_name\":\"L\",\"last_name\":\"L\"}"
+      expect(struct.to_json).to eq "{\"id\":1,\"first_name\":\"L\",\"last_name\":\"L\"}"
     end
   end
 end

--- a/spec/unit/struct_spec.rb
+++ b/spec/unit/struct_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require 'byebug'
+
+RSpec.describe Hanami::DB::Struct do
+  let!(:config) do
+    ROM::Configuration.new(:sql, 'sqlite::memory') do |conf|
+      conf.default.create_table(:users) do
+        primary_key :id
+        column :first_name, String
+        column :last_name, String
+      end
+
+      conf.relation(:users) do
+        schema(infer: true)
+      end
+    end
+  end
+
+  let(:rom) { ROM.container(config) }
+
+  before do
+    module Test
+      module Entities
+        class User < Hanami::DB::Struct
+          def full_name
+            "#{first_name} #{last_name}"
+          end
+        end
+      end
+
+      class UserRepo < ROM::Repository[:users]
+        struct_namespace Entities
+      end
+    end
+  end
+
+  describe "#to_json" do
+    before do
+      rom.relations[:users].changeset(:create, id: 1, first_name: "L", last_name: "L").commit
+    end
+
+    it "converts to json" do
+      repo = Test::UserRepo.new(rom)
+      struct = repo.users.by_pk(1).one!
+      expect(struct.full_name).to eq "L L"
+      byebug
+      expect(struct.to_json).to eq "{\"first_name\":\"L\",\"last_name\":\"L\"}"
+    end
+  end
+end

--- a/spec/unit/struct_spec.rb
+++ b/spec/unit/struct_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe Hanami::DB::Struct do
   let!(:config) do
-    ROM::Configuration.new(:sql, 'sqlite::memory') do |conf|
+    ROM::Configuration.new(:sql, "sqlite::memory") do |conf|
       conf.default.create_table(:users) do
         primary_key :id
         column :first_name, String


### PR DESCRIPTION
https://github.com/orgs/hanami/projects/6/views/1?pane=issue&itemId=70528802

This just adds a simple json conversion to struct attributes. Dumps to hash and then json.

I saw the issue description mentioned that it could also be moved to ROM or DRY gems, but I found two discussion that convinced me against it:

https://github.com/dry-rb/dry-struct/issues/166 here Nikita said "Serializing to JSON is not part of the gem and I'm against mixing concerns in general."  and in the ROM thread, there was a similar mention, by Piotr https://github.com/rom-rb/rom/issues/403 "In general I would recommend encapsulating json serialization/deserialization with your own APIs, instead of referring to 3rd party gems"

So i thought its best not to nest this method too deep in those gems
