### PR TITLE
Use new public API from rom-repository

### DIFF
--- a/hanami-db.gemspec
+++ b/hanami-db.gemspec
@@ -21,8 +21,8 @@ Gem::Specification.new do |spec|
   }
 
   spec.required_ruby_version = ">= 3.1"
-  spec.add_dependency "rom", "~> 5.3"
-  spec.add_dependency "rom-sql", "~> 3.6", ">= 3.6.4"
+  spec.add_dependency "rom", "~> 5.4", ">= 5.4.1"
+  spec.add_dependency "rom-sql", "~> 3.7"
   spec.add_dependency "zeitwerk", "~> 2.6"
 
   spec.extra_rdoc_files = Dir["README*", "LICENSE*"]

--- a/lib/hanami/db/repo.rb
+++ b/lib/hanami/db/repo.rb
@@ -40,7 +40,7 @@ module Hanami
         # means _every_ repo ends up with an inferred root, many of which will not exist as
         # relations. To avoid errors from fetching these non-existent relations, check first before
         # setting the root.
-        @root = set_relation(self.class.root) if set_relation?(self.class.root)
+        @root = prepare_relation(self.class.root) if set_relation?(self.class.root)
       end
 
       private


### PR DESCRIPTION
I deprecated `Repository#set_relation`, it was a private API. It didn't set anything so the name was confusing. I added `#prepare_relation` and made it public as well. This replaces the call and updates the dependencies.